### PR TITLE
Refactor GPT player to use responses API

### DIFF
--- a/pokechamp/gpt_player.py
+++ b/pokechamp/gpt_player.py
@@ -1,7 +1,19 @@
-from openai import OpenAI
-from time import sleep
-from openai import RateLimitError
+import json
 import os
+from time import sleep
+
+from openai import APITimeoutError, OpenAI, RateLimitError
+
+
+LEGACY_MODEL_PROVIDER_CONFIG = {
+    "gpt-4o": {"model": "gpt-4o-latest"},
+    "gpt-4o-mini": {"model": "gpt-4o-mini"},
+    "gpt-4.1": {"model": "gpt-4.1"},
+    "gpt-4.1-mini": {"model": "gpt-4.1-mini"},
+    "gpt-5": {"model": "gpt-5", "reasoning": {"effort": "medium"}},
+    "gpt-5-mini": {"model": "gpt-5-mini", "reasoning": {"effort": "low"}},
+}
+
 
 class GPTPlayer():
     def __init__(self, api_key=""):
@@ -9,82 +21,156 @@ class GPTPlayer():
             self.api_key = os.getenv('OPENAI_API_KEY')
         else:
             self.api_key = api_key
+        self._client = OpenAI(api_key=self.api_key)
         self.completion_tokens = 0
         self.prompt_tokens = 0
+        self.reasoning_tokens = 0
 
-    def get_LLM_action(self, system_prompt, user_prompt, model='gpt-4o', temperature=0.7, json_format=False, seed=None, stop=[], max_tokens=200, actions=None) -> str:
-        client = OpenAI(api_key=self.api_key)
-        # client = AzureOpenAI()
+    def get_model_config(self, model_name: str) -> dict:
+        if not model_name:
+            return {"model": "gpt-4o-latest"}
+        return LEGACY_MODEL_PROVIDER_CONFIG.get(model_name, {"model": model_name})
+
+    def _build_actions_schema(self, actions=None):
+        moves = []
+        switches = []
+        if actions and isinstance(actions, (list, tuple)):
+            if len(actions) > 0 and isinstance(actions[0], (list, tuple)):
+                moves = [m for m in actions[0] if isinstance(m, str)]
+            if len(actions) > 1 and isinstance(actions[1], (list, tuple)):
+                switches = [s for s in actions[1] if isinstance(s, str)]
+
+        properties = {
+            "thought": {"type": "string", "description": "Optional reasoning steps."},
+            "move": {"type": "string", "description": "Name of the move to use."},
+            "switch": {"type": "string", "description": "Name of the Pokémon to switch to."},
+            "dynamax": {"type": "string", "description": "Move to use while Dynamaxing."},
+            "terastallize": {"type": "string", "description": "Move to use when Terastallizing."},
+            "decision": {
+                "type": "object",
+                "additionalProperties": True,
+                "description": "Final decision selected from provided options.",
+            },
+            "option_1": {"type": "object", "additionalProperties": True},
+            "option_2": {"type": "object", "additionalProperties": True},
+            "option_3": {"type": "object", "additionalProperties": True},
+        }
+
+        if moves:
+            properties["move"]["enum"] = moves
+        if switches:
+            properties["switch"]["enum"] = switches
+
+        schema = {
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": True,
+        }
+
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "battle_action",
+                "schema": schema
+            }
+        }
+
+    def _build_generic_json_schema(self):
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "generic_json",
+                "schema": {"type": "object", "additionalProperties": True}
+            }
+        }
+
+    def _extract_response_output(self, response):
+        text_output = getattr(response, "output_text", None)
+        if text_output:
+            return text_output
+
+        output_items = getattr(response, "output", None)
+        if output_items:
+            for item in output_items:
+                contents = getattr(item, "content", None)
+                if not contents:
+                    continue
+                for content in contents:
+                    if hasattr(content, "json") and content.json is not None:
+                        return json.dumps(content.json)
+                    if hasattr(content, "text") and content.text is not None:
+                        return content.text
+        return ""
+
+    def _update_usage(self, response):
+        usage = getattr(response, "usage", None)
+        if not usage:
+            return
+        self.completion_tokens += getattr(usage, "completion_tokens", 0) or 0
+        self.prompt_tokens += getattr(usage, "prompt_tokens", 0) or 0
+        self.reasoning_tokens += getattr(usage, "reasoning_tokens", 0) or 0
+
+    def _create_request_payload(self, system_prompt, user_prompt, model_config, temperature, max_tokens, json_format, actions):
+        if model_config is None:
+            model_config = self.get_model_config(None)
+        payload = {
+            "model": model_config.get("model"),
+            "input": [
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": system_prompt}]
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": user_prompt}]
+                }
+            ],
+            "temperature": temperature,
+            "max_output_tokens": max_tokens,
+        }
+
+        if model_config.get("reasoning"):
+            payload["reasoning"] = model_config["reasoning"]
+        if json_format:
+            payload["response_format"] = self._build_actions_schema(actions)
+
+        return payload
+
+    def get_LLM_action(self, system_prompt, user_prompt, model='gpt-4o', temperature=0.7, json_format=False, seed=None, stop=[],
+ max_tokens=200, actions=None, model_config=None) -> str:
+        resolved_config = model_config or self.get_model_config(model)
+        request_payload = self._create_request_payload(system_prompt, user_prompt, resolved_config, temperature, max_tokens, json_format, actions)
+
         try:
-            if json_format:
-                response = client.chat.completions.create(
-                    response_format={"type": "json_object"},
-                    model='gpt-4o',
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt}
-                    ],
-                    temperature=temperature,
-                    stream=False,
-                    # seed=seed,
-                    stop=stop,
-                    max_tokens=max_tokens
-                )
-            else:
-                response = client.chat.completions.create(
-                    model=model,
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt}
-                    ],
-                    temperature=temperature,
-                    stream=False,
-                    stop=stop,
-                    max_tokens=max_tokens
-                )
-        except RateLimitError:
-            # sleep 5 seconds and try again
-            sleep(5)  
-            print('rate limit error')
+            response = self._client.responses.create(**request_payload)
+        except (RateLimitError, APITimeoutError):
+            sleep(5)
+            print('rate limit or timeout error')
             return self.get_LLM_action(system_prompt, user_prompt, model, temperature, json_format, seed, stop, max_tokens, actions)
-        outputs = response.choices[0].message.content
-        # log completion tokens
-        self.completion_tokens += response.usage.completion_tokens
-        self.prompt_tokens += response.usage.prompt_tokens
+
+        outputs = self._extract_response_output(response)
+        self._update_usage(response)
         if json_format:
             return outputs, True
         return outputs, False
-    
-    def get_LLM_query(self, system_prompt, user_prompt, temperature=0.7, model='gpt-4o', json_format=False, seed=None, stop=[], max_tokens=200):
-        client = OpenAI(api_key=self.api_key)
-        # client = AzureOpenAI()
-        try:
-            output_padding = ''
-            if json_format:
-                output_padding  = '\n{"'
-                
-            response = client.chat.completions.create(
-                model=model,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt+output_padding}
-                ],
-                temperature=temperature,
-                stream=False,
-                stop=stop,
-                max_tokens=max_tokens
-            )
-            message = response.choices[0].message.content
-        except RateLimitError:
-            # sleep 5 seconds and try again
-            sleep(5)  
-            print('rate limit error1')
-            return self.get_LLM_query(system_prompt, user_prompt, temperature, model, json_format, seed, stop, max_tokens)
-        
+
+    def get_LLM_query(self, system_prompt, user_prompt, temperature=0.7, model='gpt-4o', json_format=False, seed=None, stop=[],
+ max_tokens=200, model_config=None):
+        resolved_config = model_config or self.get_model_config(model)
+        request_payload = self._create_request_payload(system_prompt, user_prompt, resolved_config, temperature, max_tokens, json_format, None)
         if json_format:
-            json_start = 0
-            json_end = message.find('}') + 1 # find the first "}
-            message_json = '{"' + message[json_start:json_end]
-            if len(message_json) > 0:
-                return message_json, True
+            request_payload["response_format"] = self._build_generic_json_schema()
+
+        try:
+            response = self._client.responses.create(**request_payload)
+        except (RateLimitError, APITimeoutError):
+            sleep(5)
+            print('rate limit or timeout error1')
+            return self.get_LLM_query(system_prompt, user_prompt, temperature, model, json_format, seed, stop, max_tokens)
+
+        message = self._extract_response_output(response)
+        self._update_usage(response)
+
+        if json_format:
+            return message, True
         return message, False

--- a/tests/test_gpt_player_responses.py
+++ b/tests/test_gpt_player_responses.py
@@ -1,0 +1,66 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pokechamp.gpt_player import GPTPlayer, LEGACY_MODEL_PROVIDER_CONFIG
+
+
+class FakeResponse(SimpleNamespace):
+    pass
+
+
+class FakeContent(SimpleNamespace):
+    pass
+
+
+class FakeOutput(SimpleNamespace):
+    pass
+
+
+@pytest.fixture
+def mock_responses_client():
+    with patch("pokechamp.gpt_player.OpenAI") as mock_openai:
+        client = MagicMock()
+        mock_openai.return_value = client
+        yield client
+
+
+def test_responses_parsing_with_reasoning(mock_responses_client):
+    usage = SimpleNamespace(prompt_tokens=21, completion_tokens=11, reasoning_tokens=5)
+    reasoning_trace = [
+        {"type": "chain_of_thought", "content": [{"type": "text", "text": "Step one"}]}
+    ]
+    fake_json = {"move": "thunderbolt"}
+    response = FakeResponse(
+        output=[FakeOutput(content=[FakeContent(json=fake_json)])],
+        usage=usage,
+        reasoning=reasoning_trace,
+    )
+    mock_responses_client.responses.create.return_value = response
+
+    player = GPTPlayer(api_key="test-key")
+    action, is_json = player.get_LLM_action(
+        system_prompt="system",
+        user_prompt="user",
+        model="gpt-5",
+        temperature=0.1,
+        json_format=True,
+        max_tokens=128,
+        actions=[["thunderbolt"], ["pikachu"]],
+    )
+
+    assert json.loads(action) == fake_json
+    assert is_json is True
+    assert player.completion_tokens == usage.completion_tokens
+    assert player.prompt_tokens == usage.prompt_tokens
+    assert player.reasoning_tokens == usage.reasoning_tokens
+
+    mock_responses_client.responses.create.assert_called_once()
+    called_kwargs = mock_responses_client.responses.create.call_args.kwargs
+    assert called_kwargs["model"] == LEGACY_MODEL_PROVIDER_CONFIG["gpt-5"]["model"]
+    assert "response_format" in called_kwargs
+    move_schema = called_kwargs["response_format"]["json_schema"]["schema"]["properties"]["move"]
+    assert move_schema["enum"] == ["thunderbolt"]
+    assert "reasoning" in called_kwargs


### PR DESCRIPTION
## Summary
- migrate the GPT player to the OpenAI Responses API, including provider mappings, structured JSON schemas, and usage tracking for reasoning tokens
- update the LLM player to forward resolved provider configuration to GPT-based agents
- add unit coverage that validates parsing of Responses replies containing reasoning traces

## Testing
- pytest tests/test_gpt_player_responses.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d916bec48331951217fb570848af