### PR TITLE
Add Claude player with structured reasoning support

### DIFF
--- a/pokechamp/claude_player.py
+++ b/pokechamp/claude_player.py
@@ -1,0 +1,274 @@
+"""Anthropic Claude integration for PokéChamp."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import anthropic
+
+from pokechamp.reasoning_config import ReasoningConfig
+
+
+class ClaudePlayer:
+    """Wrapper around the Anthropic SDK providing PokéChamp's interface."""
+
+    def __init__(self, api_key: str = "") -> None:
+        self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY", "")
+        self.client = anthropic.Anthropic(api_key=self.api_key)  # type: ignore[arg-type]
+
+        self.completion_tokens = 0
+        self.prompt_tokens = 0
+        self.output_tokens = 0
+        self.thinking_tokens = 0
+        self.reasoning_traces: List[str] = []
+
+        self.reasoning_config = ReasoningConfig()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get_LLM_action(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str = "claude-3.5-sonnet",
+        temperature: float = 0.7,
+        json_format: bool = False,
+        seed: Optional[int] = None,
+        stop: Optional[Sequence[str]] = None,
+        max_tokens: int = 200,
+        actions: Optional[Sequence[Iterable[str]]] = None,
+    ) -> Tuple[str, bool]:
+        """Return the model output, enforcing JSON when requested."""
+
+        response, parser = self._invoke_client(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            model=model,
+            temperature=temperature,
+            stop=stop,
+            max_tokens=max_tokens,
+            json_format=json_format,
+            actions=actions,
+            seed=seed,
+        )
+
+        self._record_usage(response)
+        output, is_json = parser(response, json_format=json_format)
+        return output, is_json
+
+    def get_LLM_query(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        temperature: float = 0.7,
+        model: str = "claude-3.5-sonnet",
+        json_format: bool = False,
+        seed: Optional[int] = None,
+        stop: Optional[Sequence[str]] = None,
+        max_tokens: int = 200,
+    ) -> Tuple[str, bool]:
+        response, parser = self._invoke_client(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            model=model,
+            temperature=temperature,
+            stop=stop,
+            max_tokens=max_tokens,
+            json_format=json_format,
+            actions=None,
+            seed=seed,
+        )
+
+        self._record_usage(response)
+        output, is_json = parser(response, json_format=json_format)
+        return output, is_json
+
+    # ------------------------------------------------------------------
+    # Client helpers
+    # ------------------------------------------------------------------
+    def _invoke_client(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str,
+        temperature: float,
+        stop: Optional[Sequence[str]],
+        max_tokens: int,
+        json_format: bool,
+        actions: Optional[Sequence[Iterable[str]]],
+        seed: Optional[int],
+    ) -> Tuple[Any, Any]:
+        normalized_model = self._normalize_model(model)
+        thinking = self._build_thinking_config(normalized_model)
+
+        request_args: Dict[str, Any] = {
+            "model": normalized_model,
+            "system": system_prompt or None,
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": user_prompt},
+                    ],
+                }
+            ],
+            "temperature": temperature,
+            "max_output_tokens": max_tokens,
+        }
+        if stop:
+            request_args["stop_sequences"] = list(stop)
+        if thinking:
+            request_args["thinking"] = thinking
+        if seed is not None:
+            request_args["metadata"] = {"seed": seed}
+
+        parser = self._parse_responses_output
+        if hasattr(self.client, "responses"):
+            if json_format and actions is not None:
+                request_args["output_json_schema"] = self.reasoning_config.build_output_schema(actions)
+            response = self.client.responses.create(**request_args)
+        else:  # pragma: no cover - fallback for legacy SDKs
+            parser = self._parse_messages_output
+            request_args = self._convert_to_messages_request(request_args, actions, json_format)
+            response = self.client.messages.create(**request_args)
+
+        return response, parser
+
+    def _convert_to_messages_request(
+        self,
+        request_args: Dict[str, Any],
+        actions: Optional[Sequence[Iterable[str]]],
+        json_format: bool,
+    ) -> Dict[str, Any]:
+        messages_request = {
+            "model": request_args["model"],
+            "system": request_args.get("system"),
+            "messages": request_args["input"],
+            "temperature": request_args.get("temperature"),
+            "max_output_tokens": request_args.get("max_output_tokens"),
+        }
+        if "stop_sequences" in request_args:
+            messages_request["stop_sequences"] = request_args["stop_sequences"]
+        if "thinking" in request_args:
+            messages_request["thinking"] = request_args["thinking"]
+        if json_format and actions is not None:
+            tool_schema = self.reasoning_config.build_tool_schema(actions)
+            messages_request["tools"] = [tool_schema]
+            messages_request["tool_choice"] = {"type": "tool", "name": tool_schema["name"]}
+        return messages_request
+
+    # ------------------------------------------------------------------
+    # Parsing utilities
+    # ------------------------------------------------------------------
+    def _parse_responses_output(self, response: Any, json_format: bool) -> Tuple[str, bool]:
+        json_payload: Optional[Dict[str, Any]] = None
+        text_parts: List[str] = []
+
+        for block in self._iter_blocks(getattr(response, "output", None)):
+            block_type = block.get("type")
+            if block_type == "thinking":
+                reasoning_text = self._extract_text(block.get("content"))
+                if reasoning_text:
+                    self.reasoning_traces.append(reasoning_text)
+            elif block_type == "output_json":
+                json_payload = self._extract_json(block.get("content"))
+            else:
+                text = self._extract_text(block.get("content"))
+                if text:
+                    text_parts.append(text)
+
+        if json_format and json_payload is not None:
+            return self._encode_json(json_payload), True
+
+        fallback = getattr(response, "output_text", None)
+        if fallback:
+            text_parts.append(fallback)
+
+        return "\n".join([part for part in text_parts if part]), json_format and json_payload is not None
+
+    def _parse_messages_output(self, response: Any, json_format: bool) -> Tuple[str, bool]:
+        json_payload: Optional[Dict[str, Any]] = None
+        text_parts: List[str] = []
+
+        for block in self._iter_blocks(getattr(response, "content", None)):
+            block_type = block.get("type")
+            if block_type == "thinking":
+                reasoning_text = self._extract_text(block.get("content"))
+                if reasoning_text:
+                    self.reasoning_traces.append(reasoning_text)
+            elif block_type == "tool_use":
+                json_payload = block.get("input")
+            else:
+                text = self._extract_text(block.get("content"))
+                if text:
+                    text_parts.append(text)
+
+        if json_format and json_payload is not None:
+            return self._encode_json(json_payload), True
+
+        return "\n".join([part for part in text_parts if part]), json_format and json_payload is not None
+
+    def _iter_blocks(self, blocks: Optional[Iterable[Any]]) -> Iterable[Dict[str, Any]]:
+        if not blocks:
+            return []
+        normalized: List[Dict[str, Any]] = []
+        for block in blocks:
+            if hasattr(block, "to_dict"):
+                normalized.append(block.to_dict())  # type: ignore[call-arg]
+            elif isinstance(block, dict):
+                normalized.append(block)
+            else:
+                normalized.append(getattr(block, "__dict__", {"type": "text", "content": str(block)}))
+        return normalized
+
+    def _extract_text(self, content: Any) -> str:
+        if not content:
+            return ""
+        if isinstance(content, str):
+            return content
+        texts: List[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text":
+                    texts.append(item.get("text", ""))
+                elif item.get("type") == "thinking":
+                    texts.append(self._extract_text(item.get("content")))
+        return "\n".join([text for text in texts if text])
+
+    def _extract_json(self, content: Any) -> Optional[Dict[str, Any]]:
+        if not content:
+            return None
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "json":
+                    return item.get("json")
+        return None
+
+    def _encode_json(self, payload: Dict[str, Any]) -> str:
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+    def _record_usage(self, response: Any) -> None:
+        usage = getattr(response, "usage", None)
+        if not usage:
+            return
+        input_tokens = getattr(usage, "input_tokens", 0)
+        output_tokens = getattr(usage, "output_tokens", 0)
+        thinking_tokens = getattr(usage, "thinking_tokens", 0)
+        self.prompt_tokens += input_tokens
+        self.completion_tokens += output_tokens
+        self.output_tokens += output_tokens
+        self.thinking_tokens += thinking_tokens
+
+    def _normalize_model(self, model: str) -> str:
+        if model.startswith("anthropic/"):
+            return model.split("/", 1)[1]
+        return model
+
+    def _build_thinking_config(self, model: str) -> Optional[Dict[str, Any]]:
+        supported_prefixes = ("claude-3.5-sonnet", "claude-4.5")
+        if any(model.startswith(prefix) for prefix in supported_prefixes):
+            return {"type": "enabled", "budget_tokens": self.reasoning_config.thinking_budget_tokens}
+        return None

--- a/pokechamp/llm_player.py
+++ b/pokechamp/llm_player.py
@@ -22,6 +22,7 @@ from poke_env.data.gen_data import GenData
 from pokechamp.gpt_player import GPTPlayer
 from pokechamp.llama_player import LLAMAPlayer
 from pokechamp.openrouter_player import OpenRouterPlayer
+from pokechamp.claude_player import ClaudePlayer
 from pokechamp.gemini_player import GeminiPlayer
 from pokechamp.ollama_player import OllamaPlayer
 from pokechamp.data_cache import (
@@ -111,13 +112,15 @@ class LLMPlayer(Player):
                 model_name = backend.replace('ollama/', '')
                 print(f"Using Ollama with model: {model_name}")
                 self.llm = OllamaPlayer(model=model_name, device=device)
+            elif backend.startswith('anthropic/'):
+                self.llm = ClaudePlayer(self.api_key)
             elif 'gpt' in backend and not backend.startswith('openai/'):
                 self.llm = GPTPlayer(self.api_key)
             elif 'llama' == backend:
                 self.llm = LLAMAPlayer(device=device)
             elif 'gemini' in backend:
                 self.llm = GeminiPlayer(self.api_key)
-            elif backend.startswith(('openai/', 'anthropic/', 'google/', 'meta/', 'mistral/', 'cohere/', 'perplexity/', 'deepseek/', 'microsoft/', 'nvidia/', 'huggingface/', 'together/', 'replicate/', 'fireworks/', 'localai/', 'vllm/', 'sagemaker/', 'vertex/', 'bedrock/', 'azure/', 'custom/')):
+            elif backend.startswith(('openai/', 'google/', 'meta/', 'mistral/', 'cohere/', 'perplexity/', 'deepseek/', 'microsoft/', 'nvidia/', 'huggingface/', 'together/', 'replicate/', 'fireworks/', 'localai/', 'vllm/', 'sagemaker/', 'vertex/', 'bedrock/', 'azure/', 'custom/')):
                 # OpenRouter supports hundreds of models from various providers
                 self.llm = OpenRouterPlayer(self.api_key)
             else:

--- a/pokechamp/reasoning_config.py
+++ b/pokechamp/reasoning_config.py
@@ -1,0 +1,99 @@
+"""Reasoning configuration utilities for LLM integrations.
+
+This module centralizes the JSON schema used to enforce
+structured outputs from reasoning-capable language models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+
+def _unique_sequence(values: Optional[Sequence[str]]) -> List[str]:
+    """Return a list with duplicates and falsy values removed while preserving order."""
+    seen = set()
+    result: List[str] = []
+    if not values:
+        return result
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+@dataclass
+class ReasoningConfig:
+    """Shared configuration for reasoning-focused model integrations."""
+
+    thinking_budget_tokens: int = 1024
+    tool_name: str = "choose_battle_action"
+    tool_description: str = (
+        "Select the next action for the Pokémon battle agent. Choose either a move "
+        "to execute or a Pokémon to switch into."
+    )
+    include_thought_field: bool = True
+    allow_additional_properties: bool = False
+
+    def build_action_schema(self, actions: Optional[Sequence[Iterable[str]]] = None) -> Dict[str, Any]:
+        """Create a JSON schema describing the valid battle action payload."""
+        moves: List[str] = []
+        switches: List[str] = []
+        if actions:
+            if len(actions) > 0:
+                moves = _unique_sequence(actions[0])
+            if len(actions) > 1:
+                switches = _unique_sequence(actions[1])
+
+        properties: Dict[str, Any] = {}
+        required_choices: List[Dict[str, Any]] = []
+
+        if moves:
+            move_schema = {"type": "string", "enum": moves}
+            properties["move"] = move_schema
+            # Gimmick actions reuse the move list for validation
+            properties["dynamax"] = move_schema
+            properties["terastallize"] = move_schema
+            required_choices.extend(
+                [{"required": ["move"]}, {"required": ["dynamax"]}, {"required": ["terastallize"]}]
+            )
+        else:
+            # When no moves are available we keep gimmick keys optional for completeness.
+            properties["dynamax"] = {"type": "string"}
+            properties["terastallize"] = {"type": "string"}
+
+        if switches:
+            properties["switch"] = {"type": "string", "enum": switches}
+            required_choices.append({"required": ["switch"]})
+        else:
+            properties["switch"] = {"type": "string"}
+
+        if self.include_thought_field:
+            properties["thought"] = {"type": "string"}
+
+        schema: Dict[str, Any] = {
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": self.allow_additional_properties,
+        }
+
+        choice_constraints = [rule for rule in required_choices if rule.get("required")]
+        if choice_constraints:
+            schema["anyOf"] = choice_constraints
+
+        return schema
+
+    def build_output_schema(self, actions: Optional[Sequence[Iterable[str]]] = None) -> Dict[str, Any]:
+        """Return an Anthropic-compatible ``output_json_schema`` payload."""
+        return {"type": "json_schema", "json_schema": self.build_action_schema(actions)}
+
+    def build_tool_schema(self, actions: Optional[Sequence[Iterable[str]]] = None) -> Dict[str, Any]:
+        """Return an Anthropic tool schema for structured output enforcement."""
+        return {
+            "type": "function",
+            "name": self.tool_name,
+            "description": self.tool_description,
+            "input_schema": self.build_action_schema(actions),
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ requests
 pytest
 huggingface-hub
 termcolor
+anthropic

--- a/tests/test_claude_player.py
+++ b/tests/test_claude_player.py
@@ -1,0 +1,91 @@
+import json
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# Provide a lightweight stub for the anthropic SDK so the module can be imported.
+if "anthropic" not in sys.modules:
+    anthropic_stub = types.ModuleType("anthropic")
+
+    class _FakeAnthropicClient:
+        def __init__(self, *args, **kwargs):
+            self.responses = SimpleNamespace(create=MagicMock())
+            self.messages = SimpleNamespace(create=MagicMock())
+            anthropic_stub.last_client = self
+
+    anthropic_stub.Anthropic = _FakeAnthropicClient
+    sys.modules["anthropic"] = anthropic_stub
+else:
+    anthropic_stub = sys.modules["anthropic"]
+
+from pokechamp.claude_player import ClaudePlayer
+
+
+@pytest.fixture
+def fake_client():
+    # Instantiate a new client for each test to reset mocks
+    player = ClaudePlayer(api_key="test-key")
+    client = anthropic_stub.last_client
+    client.responses.create.reset_mock()
+    client.messages.create.reset_mock()
+    return player, client
+
+
+def test_claude_player_enforces_schema_and_extracts_action(fake_client):
+    player, client = fake_client
+    fake_response = SimpleNamespace(
+        output=[
+            {"type": "thinking", "content": [{"type": "text", "text": "considering options"}]},
+            {"type": "output_json", "content": [{"type": "json", "json": {"move": "tackle"}}]},
+        ],
+        usage=SimpleNamespace(input_tokens=11, output_tokens=7, thinking_tokens=3),
+        output_text="irrelevant",
+    )
+    client.responses.create.return_value = fake_response
+
+    output, is_json = player.get_LLM_action(
+        system_prompt="system",
+        user_prompt="user",
+        model="anthropic/claude-3.5-sonnet",
+        json_format=True,
+        actions=[["tackle"], []],
+    )
+
+    assert output == json.dumps({"move": "tackle"}, separators=(",", ":"))
+    assert is_json is True
+    assert player.prompt_tokens == 11
+    assert player.completion_tokens == 7
+    assert player.output_tokens == 7
+    assert player.thinking_tokens == 3
+    assert "considering options" in player.reasoning_traces[-1]
+
+    kwargs = client.responses.create.call_args.kwargs
+    assert kwargs["output_json_schema"]["json_schema"]["properties"]["move"]["enum"] == ["tackle"]
+    assert kwargs["thinking"]["type"] == "enabled"
+
+
+def test_claude_player_returns_text_when_no_schema(fake_client):
+    player, client = fake_client
+    fake_response = SimpleNamespace(
+        output=[
+            {"type": "output_text", "content": [{"type": "text", "text": "battle summary"}]},
+        ],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=4, thinking_tokens=0),
+        output_text="battle summary",
+    )
+    client.responses.create.return_value = fake_response
+
+    output, is_json = player.get_LLM_action(
+        system_prompt="system",
+        user_prompt="user",
+        model="anthropic/claude-2",
+        json_format=False,
+    )
+
+    assert "battle summary" in output
+    assert is_json is False
+    kwargs = client.responses.create.call_args.kwargs
+    assert "output_json_schema" not in kwargs


### PR DESCRIPTION
## Summary
- add a dedicated AnthropIc Claude backend that supports thinking traces and schema-controlled JSON actions
- share a reasoning configuration helper for building Anthropic tool/output schemas and update LLMPlayer to use the new backend
- cover the integration with tests that stub Anthropic responses and verify JSON extraction, plus document the anthropic dependency

## Testing
- pytest tests/test_claude_player.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d9178c3c83318c77662e026c998e