### PR TITLE
Enhance Gemini reasoning support

### DIFF
--- a/pokechamp/gemini_player.py
+++ b/pokechamp/gemini_player.py
@@ -1,125 +1,327 @@
-from google import genai
-from time import sleep
-import os, sys
-import json
+from __future__ import annotations
 
-class GeminiPlayer():
-    def __init__(self, api_key=""):
+import json
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+from google import genai
+
+
+@dataclass(frozen=True)
+class GeminiModelConfig:
+    """Configuration metadata for a Gemini model alias."""
+
+    api_model: str
+    requires_reasoning: bool = False
+
+
+@dataclass
+class ReasoningConfig:
+    """Provider specific knobs for Gemini reasoning models."""
+
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    safety_settings: Optional[Sequence[Any]] = None
+    seed: Optional[int] = None
+    thinking_budget: Optional[int] = None
+    include_thoughts: Optional[bool] = None
+    response_mime_type: Optional[str] = None
+
+
+class GeminiPlayer:
+    def __init__(self, api_key: str = "") -> None:
         print("api_key", api_key)
         if api_key == "":
-            self.api_key = os.getenv('GEMINI_API_KEY')
+            self.api_key = os.getenv("GEMINI_API_KEY")
         else:
             self.api_key = api_key
-        
+
         # Configure the Gemini API
         self.client = genai.Client(api_key=self.api_key)
-        
+
         self.completion_tokens = 0
         self.prompt_tokens = 0
-        
-        # Map common model names to official API names
-        self.model_mapping = {
+        self.last_thinking_trace: List[str] = []
+
+        # Map common model names to official API names and reasoning requirements
+        self.model_mapping: Dict[str, Union[GeminiModelConfig, str]] = {
             # Default to latest Gemini 2.5
-            'gemini-flash': 'gemini-2.5-flash',
-            'gemini-flash-2.5': 'gemini-2.5-flash',
-            'gemini-pro': 'gemini-2.5-pro',
-            'gemini-pro-2.5': 'gemini-2.5-pro',
-            
+            "gemini-flash": GeminiModelConfig("gemini-2.5-flash"),
+            "gemini-flash-2.5": GeminiModelConfig("gemini-2.5-flash"),
+            "gemini-pro": GeminiModelConfig("gemini-2.5-pro"),
+            "gemini-pro-2.5": GeminiModelConfig("gemini-2.5-pro"),
+
+            # Gemini 2.5 reasoning variants
+            "gemini-2.5-pro-exp": GeminiModelConfig("gemini-2.5-pro-exp", requires_reasoning=True),
+            "gemini-2.5-pro-experimental": GeminiModelConfig("gemini-2.5-pro-exp", requires_reasoning=True),
+            "gemini-2.5-flash-thinking": GeminiModelConfig("gemini-2.5-flash-thinking", requires_reasoning=True),
+            "gemini-flash-thinking": GeminiModelConfig("gemini-2.5-flash-thinking", requires_reasoning=True),
+
             # Gemini 2.0 models
-            'gemini-2.0-flash': 'gemini-2.0-flash',
-            'gemini-2.0-flash-lite': 'gemini-2.0-flash-lite',
-            'gemini-2.0-pro': 'gemini-2.0-pro-experimental',
-            'gemini-2.0-pro-experimental': 'gemini-2.0-pro-experimental',
-            'gemini-2.0-flash-thinking': 'gemini-2.0-flash-thinking-exp',
-            
+            "gemini-2.0-flash": GeminiModelConfig("gemini-2.0-flash"),
+            "gemini-2.0-flash-lite": GeminiModelConfig("gemini-2.0-flash-lite"),
+            "gemini-2.0-pro": GeminiModelConfig("gemini-2.0-pro-experimental"),
+            "gemini-2.0-pro-experimental": GeminiModelConfig("gemini-2.0-pro-experimental"),
+            "gemini-2.0-flash-thinking": GeminiModelConfig(
+                "gemini-2.0-flash-thinking-exp", requires_reasoning=True
+            ),
+            "gemini-2.0-flash-thinking-exp": GeminiModelConfig(
+                "gemini-2.0-flash-thinking-exp", requires_reasoning=True
+            ),
+
             # Gemini 1.5 models (legacy support)
-            'gemini-1.5-flash': 'gemini-1.5-flash',
-            'gemini-1.5-pro': 'gemini-1.5-pro',
+            "gemini-1.5-flash": GeminiModelConfig("gemini-1.5-flash"),
+            "gemini-1.5-pro": GeminiModelConfig("gemini-1.5-pro"),
         }
 
-    def get_LLM_action(self, system_prompt, user_prompt, model='gemini-2.0-flash', temperature=0.7, json_format=False, seed=None, stop=[], max_tokens=1000, actions=None) -> str:
+    def get_LLM_action(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        model: str = "gemini-2.0-flash",
+        temperature: float = 0.7,
+        json_format: bool = False,
+        seed: Optional[int] = None,
+        stop: Optional[Sequence[str]] = None,
+        max_tokens: int = 1000,
+        actions: Optional[Sequence[Sequence[str]]] = None,
+        reasoning_config: Optional[ReasoningConfig] = None,
+    ) -> Tuple[str, bool]:
         try:
-            # Map model name to official API name
-            api_model_name = self.model_mapping.get(model, model)
-            
-            # Combine system and user prompts for Gemini
+            model_config = self._resolve_model_config(model)
+
+            generate_config = self._build_generate_config(
+                system_prompt=system_prompt,
+                base_temperature=temperature,
+                json_format=json_format,
+                stop_sequences=stop,
+                max_output_tokens=max_tokens,
+                reasoning_config=reasoning_config,
+                requires_reasoning=model_config.requires_reasoning,
+                actions=actions,
+                seed=seed,
+            )
+
+            response = self.client.models.generate_content(
+                model=model_config.api_model,
+                contents=user_prompt,
+                config=generate_config,
+            )
+
+            outputs, was_json = self._extract_response_payload(response, json_format)
             combined_prompt = f"{system_prompt}\n\n{user_prompt}"
-            
-            # print("=" * 80)
-            # print("GEMINI PROMPT:")
-            # print("-" * 80)
-            # print(combined_prompt)
-            # print("-" * 80)
-            
-            # Generate response
-            response = self.client.models.generate_content(model=api_model_name, contents=combined_prompt)
-            
-            # print("GEMINI RESPONSE:")
-            # print("-" * 80)
-            # print(response)
-            # print("-" * 80)
-            
-            # Extract text from response
-            outputs = response.text
-            
-            # Simple token counting approximation (Gemini doesn't provide exact counts)
-            self.completion_tokens += len(outputs.split()) * 1.3  # Approximate tokens
-            self.prompt_tokens += len(combined_prompt.split()) * 1.3
-            
-            if json_format:
-                # Handle cases where the model adds extra text before the JSON
-                # Look for the first { and last } to extract JSON
-                start_idx = outputs.find('{')
-                end_idx = outputs.rfind('}')
-                
-                if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
-                    json_content = outputs[start_idx:end_idx + 1]
-                    try:
-                        # Validate JSON
-                        json.loads(json_content)
-                        return json_content, True
-                    except json.JSONDecodeError:
-                        # If JSON is invalid, return the original output
-                        return outputs, True
-                else:
-                    # No JSON found, return original output
-                    return outputs, True
-            
-            return outputs, False
-            
-        except Exception as e:
-            print(f'Gemini API error: {e}')
+            self._update_token_usage(response, combined_prompt, outputs)
+            self.last_thinking_trace = self._extract_thinking_traces(response)
+
+            return outputs, was_json
+
+        except Exception as e:  # pragma: no cover - fail fast just like previous implementation
+            print(f"Gemini API error: {e}")
             sys.exit(1)
-            # sleep 2 seconds and try again
-            sleep(2)
-            return self.get_LLM_action(system_prompt, user_prompt, model, temperature, json_format, seed, stop, max_tokens, actions)
-    
-    def get_LLM_query(self, system_prompt, user_prompt, temperature=0.7, model='gemini-2.0-flash', json_format=False, seed=None, stop=[], max_tokens=1000):
+
+    def get_LLM_query(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        temperature: float = 0.7,
+        model: str = "gemini-2.0-flash",
+        json_format: bool = False,
+        seed: Optional[int] = None,
+        stop: Optional[Sequence[str]] = None,
+        max_tokens: int = 1000,
+        reasoning_config: Optional[ReasoningConfig] = None,
+    ) -> Tuple[str, bool]:
         try:
-            # Map model name to official API name
-            api_model_name = self.model_mapping.get(model, model)
-            
-            # Combine system and user prompts for Gemini
+            model_config = self._resolve_model_config(model)
+            generate_config = self._build_generate_config(
+                system_prompt=system_prompt,
+                base_temperature=temperature,
+                json_format=json_format,
+                stop_sequences=stop,
+                max_output_tokens=max_tokens,
+                reasoning_config=reasoning_config,
+                requires_reasoning=model_config.requires_reasoning,
+                actions=None,
+                seed=seed,
+            )
+
+            response = self.client.models.generate_content(
+                model=model_config.api_model,
+                contents=user_prompt,
+                config=generate_config,
+            )
+
+            outputs, was_json = self._extract_response_payload(response, json_format)
             combined_prompt = f"{system_prompt}\n\n{user_prompt}"
-            
-            # Generate response
-            response = self.client.models.generate_content(model=api_model_name, contents=combined_prompt)
-            
-            # Extract text from response
-            message = response.text
-            
-        except Exception as e:
-            print(f'Gemini API error2: {e}')
+            self._update_token_usage(response, combined_prompt, outputs)
+            self.last_thinking_trace = self._extract_thinking_traces(response)
+
+            return outputs, was_json
+
+        except Exception as e:  # pragma: no cover - fail fast just like previous implementation
+            print(f"Gemini API error2: {e}")
             sys.exit(1)
-            # sleep 2 seconds and try again
-            sleep(2)
-            return self.get_LLM_query(system_prompt, user_prompt, temperature, model, json_format, seed, stop, max_tokens)
-        
+
+    def _resolve_model_config(self, model: str) -> GeminiModelConfig:
+        resolved = self.model_mapping.get(model)
+        if resolved is None:
+            return GeminiModelConfig(api_model=model)
+        if isinstance(resolved, GeminiModelConfig):
+            return resolved
+        return GeminiModelConfig(api_model=resolved)
+
+    def _build_generate_config(
+        self,
+        *,
+        system_prompt: str,
+        base_temperature: float,
+        json_format: bool,
+        stop_sequences: Optional[Sequence[str]],
+        max_output_tokens: int,
+        reasoning_config: Optional[ReasoningConfig],
+        requires_reasoning: bool,
+        actions: Optional[Sequence[Sequence[str]]],
+        seed: Optional[int],
+    ) -> genai.types.GenerateContentConfig:
+        reasoning_config = reasoning_config or ReasoningConfig()
+        stop_sequences = tuple(stop_sequences) if stop_sequences else None
+
+        temperature = (
+            reasoning_config.temperature
+            if reasoning_config.temperature is not None
+            else base_temperature
+        )
+
+        config_kwargs: Dict[str, Any] = {
+            "system_instruction": system_prompt,
+            "max_output_tokens": max_output_tokens,
+        }
+
+        if temperature is not None:
+            config_kwargs["temperature"] = temperature
+        if reasoning_config.top_p is not None:
+            config_kwargs["top_p"] = reasoning_config.top_p
+        if reasoning_config.top_k is not None:
+            config_kwargs["top_k"] = reasoning_config.top_k
+        if reasoning_config.safety_settings is not None:
+            config_kwargs["safety_settings"] = reasoning_config.safety_settings
+        if seed is not None:
+            config_kwargs["seed"] = seed
+        if stop_sequences:
+            config_kwargs["stop_sequences"] = list(stop_sequences)
+
         if json_format:
-            json_start = 0
-            json_end = message.find('}') + 1  # find the first "}
-            message_json = '{"' + message[json_start:json_end]
-            if len(message_json) > 0:
-                return message_json, True
-        
-        return message, False
+            config_kwargs["response_schema"] = self._build_action_schema(actions)
+            config_kwargs["response_mime_type"] = (
+                reasoning_config.response_mime_type or "application/json"
+            )
+
+        thinking_kwargs: Dict[str, Any] = {}
+        include_thoughts = (
+            reasoning_config.include_thoughts
+            if reasoning_config.include_thoughts is not None
+            else requires_reasoning
+        )
+        if include_thoughts:
+            thinking_kwargs["include_thoughts"] = True
+        if reasoning_config.thinking_budget is not None:
+            thinking_kwargs["thinking_budget"] = reasoning_config.thinking_budget
+
+        if thinking_kwargs:
+            config_kwargs["thinking_config"] = genai.types.ThinkingConfig(**thinking_kwargs)
+
+        return genai.types.GenerateContentConfig(**config_kwargs)
+
+    def _build_action_schema(
+        self, actions: Optional[Sequence[Sequence[str]]]
+    ) -> genai.types.Schema:
+        move_schema = genai.types.Schema(type="string")
+        switch_schema = genai.types.Schema(type="string")
+
+        if actions and len(actions) >= 1:
+            moves = actions[0]
+            if moves:
+                move_schema = genai.types.Schema(
+                    type="string", enum=[move for move in moves if move]
+                )
+        if actions and len(actions) >= 2:
+            switches = actions[1]
+            if switches:
+                switch_schema = genai.types.Schema(
+                    type="string", enum=[switch for switch in switches if switch]
+                )
+
+        properties = {
+            "move": move_schema,
+            "switch": switch_schema,
+            "dynamax": genai.types.Schema(type="boolean"),
+            "terastallize": genai.types.Schema(type="string"),
+            "action": genai.types.Schema(type="string"),
+            "target": genai.types.Schema(type="string"),
+            "reason": genai.types.Schema(type="string"),
+        }
+
+        return genai.types.Schema(
+            type="object",
+            properties=properties,
+            additional_properties=True,
+        )
+
+    def _extract_response_payload(
+        self, response: genai.types.GenerateContentResponse, json_format: bool
+    ) -> Tuple[str, bool]:
+        if json_format:
+            parsed = response.parsed
+            if parsed is not None:
+                if hasattr(parsed, "model_dump"):
+                    try:
+                        parsed_payload = parsed.model_dump()
+                    except Exception:  # pragma: no cover - defensive fallback
+                        parsed_payload = getattr(parsed, "__dict__", parsed)
+                else:
+                    parsed_payload = parsed
+                return json.dumps(parsed_payload), True
+
+            # Fallback to raw text parsing if schema parsing failed
+            text_output = getattr(response, "text", "") or ""
+            try:
+                parsed_json = json.loads(text_output)
+                return json.dumps(parsed_json), True
+            except (TypeError, json.JSONDecodeError):
+                return text_output, True
+
+        text_output = getattr(response, "text", "") or ""
+        return text_output, False
+
+    def _extract_thinking_traces(
+        self, response: genai.types.GenerateContentResponse
+    ) -> List[str]:
+        traces: List[str] = []
+        for candidate in response.candidates or []:
+            content = getattr(candidate, "content", None)
+            if not content or not content.parts:
+                continue
+            for part in content.parts:
+                if getattr(part, "thought", None):
+                    text = getattr(part, "text", None)
+                    if text:
+                        traces.append(text)
+        return traces
+
+    def _update_token_usage(
+        self, response: genai.types.GenerateContentResponse, prompt: str, output: str
+    ) -> None:
+        usage = response.usage_metadata
+        if usage:
+            if usage.prompt_token_count is not None:
+                self.prompt_tokens += usage.prompt_token_count
+            if usage.candidates_token_count is not None:
+                self.completion_tokens += usage.candidates_token_count
+            if usage.thoughts_token_count is not None:
+                self.completion_tokens += usage.thoughts_token_count
+        else:
+            self.prompt_tokens += len(prompt.split()) * 1.3
+            self.completion_tokens += len(output.split()) * 1.3

--- a/tests/test_gemini_player.py
+++ b/tests/test_gemini_player.py
@@ -1,0 +1,139 @@
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+import pytest
+from google import genai
+
+from pokechamp.gemini_player import GeminiPlayer, ReasoningConfig
+
+
+class _DummyModels:
+    def __init__(self, response: Any):
+        self._response = response
+        self.kwargs: Optional[Dict[str, Any]] = None
+
+    def generate_content(self, **kwargs):
+        self.kwargs = kwargs
+        return self._response
+
+
+class _DummyClient:
+    def __init__(self, response: Any):
+        self.models = _DummyModels(response)
+
+
+def _make_usage(prompt: int, candidates: int, thoughts: int = 0) -> genai.types.GenerateContentResponseUsageMetadata:
+    return genai.types.GenerateContentResponseUsageMetadata(
+        prompt_token_count=prompt,
+        candidates_token_count=candidates,
+        thoughts_token_count=thoughts,
+    )
+
+
+def _make_thinking_response(payload: Dict[str, Any], thought: str) -> Any:
+    usage = _make_usage(prompt=10, candidates=5, thoughts=3)
+    parts = [
+        SimpleNamespace(text=thought, thought=True),
+        SimpleNamespace(text=json.dumps(payload), thought=None),
+    ]
+    candidate = SimpleNamespace(content=SimpleNamespace(parts=parts))
+    return SimpleNamespace(
+        parsed=payload,
+        text=json.dumps(payload),
+        candidates=[candidate],
+        usage_metadata=usage,
+    )
+
+
+def _make_text_response(text: str) -> Any:
+    usage = _make_usage(prompt=2, candidates=4)
+    parts = [SimpleNamespace(text=text, thought=None)]
+    candidate = SimpleNamespace(content=SimpleNamespace(parts=parts))
+    return SimpleNamespace(parsed=None, text=text, candidates=[candidate], usage_metadata=usage)
+
+
+@pytest.fixture
+def monkeypatched_client(monkeypatch):
+    created: Dict[str, Any] = {}
+
+    def _factory(response: Any):
+        dummy_client = _DummyClient(response)
+
+        def _make_client(*args, **kwargs):
+            created["client"] = dummy_client
+            return dummy_client
+
+        monkeypatch.setattr("pokechamp.gemini_player.genai.Client", _make_client)
+        return created
+
+    return _factory
+
+
+def test_gemini_player_parses_thinking_response(monkeypatched_client):
+    payload = {"move": "thunderbolt"}
+    response = _make_thinking_response(payload, "Focus on electric STAB.")
+    created = monkeypatched_client(response)
+
+    player = GeminiPlayer(api_key="test-key")
+
+    output, is_json = player.get_LLM_action(
+        "system",
+        "Pick the best move",
+        model="gemini-2.5-flash-thinking",
+        json_format=True,
+    )
+
+    assert is_json is True
+    assert json.loads(output) == payload
+    assert player.last_thinking_trace == ["Focus on electric STAB."]
+    assert player.prompt_tokens == 10
+    assert player.completion_tokens == 8
+
+    config = created["client"].models.kwargs["config"]
+    assert config.thinking_config.include_thoughts is True
+    assert config.response_schema is not None
+    assert config.response_mime_type == "application/json"
+
+
+def test_reasoning_config_overrides_generation(monkeypatched_client):
+    response = _make_text_response("{\"switch\": \"Pikachu\"}")
+    created = monkeypatched_client(response)
+
+    player = GeminiPlayer(api_key="test-key")
+
+    safety = [{"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "BLOCK_NONE"}]
+    reasoning_cfg = ReasoningConfig(
+        temperature=0.0,
+        top_p=0.2,
+        top_k=1,
+        safety_settings=safety,
+        thinking_budget=32,
+        include_thoughts=False,
+        response_mime_type="application/json",
+    )
+
+    output, is_json = player.get_LLM_action(
+        "system",
+        "Choose wisely",
+        model="gemini-2.5-pro-exp",
+        temperature=0.9,
+        json_format=True,
+        stop=["STOP"],
+        reasoning_config=reasoning_cfg,
+    )
+
+    assert is_json is True
+    assert json.loads(output) == {"switch": "Pikachu"}
+
+    config = created["client"].models.kwargs["config"]
+    assert config.temperature == 0.0
+    assert config.top_p == 0.2
+    assert config.top_k == 1
+    safety_setting = config.safety_settings[0]
+    assert safety_setting.category == genai.types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT
+    assert safety_setting.threshold == genai.types.HarmBlockThreshold.BLOCK_NONE
+    assert config.stop_sequences == ["STOP"]
+    assert config.thinking_config.thinking_budget == 32
+    # include_thoughts explicitly disabled even though model defaults to reasoning
+    assert config.thinking_config.include_thoughts is None


### PR DESCRIPTION
## Summary
- update the Gemini player to build GenerateContentConfig requests with system instructions, response schemas, and reasoning controls
- expand Gemini model alias coverage, expose a ReasoningConfig for temperature/safety tuning, and capture thinking traces
- add tests that mock reasoning responses to verify schema parsing and config plumbing

## Testing
- `pytest tests/test_gemini_player.py`


------
https://chatgpt.com/codex/tasks/task_e_68e5d917bc008331ac764413a9e0d043